### PR TITLE
feat: add onLastPageComplete callback for granular completion control

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ const App = () => {
       slides={slides}
       visible={showOnboarding}
       onComplete={() => setShowOnboarding(false)}
+      onLastPageComplete={() => {
+        // Triggered when user clicks next on the last page
+        console.log('User completed the last page!');
+        // You can perform specific actions here before onComplete is called
+      }}
       closeable={false}
       showProgress={true}
     />
@@ -133,6 +138,7 @@ const App = () => {
 | `slides` | `OnboardingSlideData[]` | **required** | Array of slide data |
 | `visible` | `boolean` | **required** | Controls modal visibility |
 | `onComplete` | `() => void` | **required** | Called when onboarding completes |
+| `onLastPageComplete` | `() => void` | `undefined` | Called when user clicks next on the last page |
 | `closeable` | `boolean` | `false` | Allow users to close before completion |
 | `showProgress` | `boolean` | `true` | Show progress dots |
 | `theme` | `OnboardingTheme` | `undefined` | Custom colors |

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -6,6 +6,7 @@ const OnboardingFlow: React.FC<OnboardingFlowProps> = ({
   slides,
   visible,
   onComplete,
+  onLastPageComplete,
   closeable = false,
   showProgress = true,
   theme,
@@ -16,6 +17,7 @@ const OnboardingFlow: React.FC<OnboardingFlowProps> = ({
       setCurrentSlide(currentSlide + 1);
     } else {
       setCurrentSlide(0);
+      onLastPageComplete?.();
       onComplete();
     }
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface OnboardingFlowProps {
   slides: OnboardingSlideData[];
   visible: boolean;
   onComplete: () => void;
+  onLastPageComplete?: () => void;
   closeable?: boolean;
   showProgress?: boolean;
   theme?: OnboardingTheme;


### PR DESCRIPTION
## Summary
This PR adds an optional `onLastPageComplete` callback prop to the OnboardingFlow component that provides developers with granular control over the completion process. The callback is triggered when users click the next button on the last slide, allowing custom actions to be performed before the main `onComplete` callback is called.

## Changes Made
- **Added `onLastPageComplete` prop** to `OnboardingFlowProps` interface in `src/types.ts`
- **Updated OnboardingFlow component** in `src/components/OnboardingFlow.tsx` to accept and call the new callback
- **Enhanced README.md** with comprehensive documentation including:
  - Usage example showing the new callback in action
  - Updated props table with the new optional parameter
  - Clear explanation of when the callback is triggered

## Key Features
- **Optional callback**: Won't break existing implementations
- **Granular control**: Triggers specifically when user clicks next on the last page
- **Execution order**: Called before `onComplete` for proper sequencing
- **Type safety**: Fully typed with TypeScript support

## Usage Example
```tsx
<OnboardingFlow
  slides={slides}
  visible={showOnboarding}
  onComplete={() => setShowOnboarding(false)}
  onLastPageComplete={() => {
    // Custom logic when user completes last page
    console.log('User completed the last page!');
    // Analytics, API calls, etc.
  }}
/>
```

## Testing
- Verified callback triggers correctly on last slide navigation
- Confirmed existing functionality remains unchanged
- Tested optional nature doesn't affect existing implementations

🤖 Generated with [Claude Code](https://claude.ai/code)