### PR TITLE
feat: add paywall support after onboarding completion

### DIFF
--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -9,22 +9,38 @@ const OnboardingFlow: React.FC<OnboardingFlowProps> = ({
   closeable = false,
   showProgress = true,
   theme,
+  showPaywall = false,
+  paywallComponent,
 }) => {
   const [currentSlide, setCurrentSlide] = useState(0);
+  const [showingPaywall, setShowingPaywall] = useState(false);
+
   const handleNext = () => {
     if (currentSlide < slides.length - 1) {
       setCurrentSlide(currentSlide + 1);
     } else {
-      setCurrentSlide(0);
-      onComplete();
+      // Check if paywall should be shown
+      if (showPaywall && paywallComponent) {
+        setShowingPaywall(true);
+      } else {
+        setCurrentSlide(0);
+        onComplete();
+      }
     }
   };
 
   const handleClose = () => {
     if (closeable) {
       setCurrentSlide(0);
+      setShowingPaywall(false);
       onComplete();
     }
+  };
+
+  const handlePaywallComplete = () => {
+    setCurrentSlide(0);
+    setShowingPaywall(false);
+    onComplete();
   };
 
   // Don't render if no slides provided
@@ -42,6 +58,8 @@ const OnboardingFlow: React.FC<OnboardingFlowProps> = ({
       closeable={closeable}
       showProgress={showProgress}
       theme={theme}
+      showPaywall={showingPaywall}
+      paywallComponent={paywallComponent ? React.cloneElement(paywallComponent as React.ReactElement<any>, { onComplete: handlePaywallComplete }) : undefined}
     />
   );
 };

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -23,6 +23,8 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({
   closeable,
   showProgress,
   theme,
+  showPaywall = false,
+  paywallComponent,
 }) => {
   const isValidSlide = currentSlide >= 0 && currentSlide < slides.length;
   const isLastSlide = isValidSlide && currentSlide === slides.length - 1;
@@ -59,69 +61,78 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({
       onRequestClose={closeable ? onClose : undefined}
     >
       <SafeAreaView style={[styles.container, { backgroundColor: theme?.backgroundColor || 'white' }]}>
-        {/* Header with optional close button */}
-        <View style={styles.header}>
-          <View style={styles.headerSpacer} />
-          {closeable && onClose && (
-            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-              <Ionicons name="close" size={24} color={theme?.closeButtonColor || '#666'} />
-            </TouchableOpacity>
-          )}
-        </View>
-
-        {/* Progress dots */}
-        {renderProgressDots()}
-
-        {/* Slide content */}
-        <View style={styles.slideContainer}>
-          {currentSlideData && currentSlideData.media && (
-            <OnboardingSlide
-              slide={currentSlideData}
-              isActive={true}
-              theme={theme}
-            />
-          )}
-          {!currentSlideData && (
-            <View style={styles.errorContainer}>
-              <Text style={styles.errorText}>Unable to load slide</Text>
+        {showPaywall && paywallComponent ? (
+          // Render paywall component in full screen
+          <View style={styles.paywallContainer}>
+            {paywallComponent}
+          </View>
+        ) : (
+          <>
+            {/* Header with optional close button */}
+            <View style={styles.header}>
+              <View style={styles.headerSpacer} />
+              {closeable && onClose && (
+                <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+                  <Ionicons name="close" size={24} color={theme?.closeButtonColor || '#666'} />
+                </TouchableOpacity>
+              )}
             </View>
-          )}
-        </View>
 
-        {/* Footer with next button */}
-        <View style={styles.footer}>
-          <TouchableOpacity
-            style={[
-              styles.nextButton,
-              { backgroundColor: theme?.buttonBackgroundColor || '#6B8E5A' },
-              isLastSlide && styles.completeButton,
-            ]}
-            onPress={onNext}
-            activeOpacity={0.8}
-          >
-            <Text style={[
-              styles.nextButtonText,
-              { color: theme?.buttonTextColor || 'white' },
-              isLastSlide && styles.completeButtonText,
-            ]}>
-              {isLastSlide ? 'Get Started' : 'Next'}
-            </Text>
-            {!isLastSlide && (
-              <Ionicons 
-                name="arrow-forward" 
-                size={20} 
-                color="white" 
-                style={styles.nextIcon}
-              />
-            )}
-          </TouchableOpacity>
+            {/* Progress dots */}
+            {renderProgressDots()}
 
-          {!isLastSlide && (
-            <Text style={styles.slideCounter}>
-              {currentSlide + 1} of {slides.length}
-            </Text>
-          )}
-        </View>
+            {/* Slide content */}
+            <View style={styles.slideContainer}>
+              {currentSlideData && currentSlideData.media && (
+                <OnboardingSlide
+                  slide={currentSlideData}
+                  isActive={true}
+                  theme={theme}
+                />
+              )}
+              {!currentSlideData && (
+                <View style={styles.errorContainer}>
+                  <Text style={styles.errorText}>Unable to load slide</Text>
+                </View>
+              )}
+            </View>
+
+            {/* Footer with next button */}
+            <View style={styles.footer}>
+              <TouchableOpacity
+                style={[
+                  styles.nextButton,
+                  { backgroundColor: theme?.buttonBackgroundColor || '#6B8E5A' },
+                  isLastSlide && styles.completeButton,
+                ]}
+                onPress={onNext}
+                activeOpacity={0.8}
+              >
+                <Text style={[
+                  styles.nextButtonText,
+                  { color: theme?.buttonTextColor || 'white' },
+                  isLastSlide && styles.completeButtonText,
+                ]}>
+                  {isLastSlide ? 'Get Started' : 'Next'}
+                </Text>
+                {!isLastSlide && (
+                  <Ionicons 
+                    name="arrow-forward" 
+                    size={20} 
+                    color="white" 
+                    style={styles.nextIcon}
+                  />
+                )}
+              </TouchableOpacity>
+
+              {!isLastSlide && (
+                <Text style={styles.slideCounter}>
+                  {currentSlide + 1} of {slides.length}
+                </Text>
+              )}
+            </View>
+          </>
+        )}
       </SafeAreaView>
     </Modal>
   );
@@ -215,6 +226,9 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#666',
     textAlign: 'center',
+  },
+  paywallContainer: {
+    flex: 1,
   },
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,8 @@ export interface OnboardingFlowProps {
   closeable?: boolean;
   showProgress?: boolean;
   theme?: OnboardingTheme;
+  showPaywall?: boolean;
+  paywallComponent?: React.ReactNode;
 }
 
 export interface OnboardingModalProps {
@@ -43,6 +45,8 @@ export interface OnboardingModalProps {
   closeable: boolean;
   showProgress: boolean;
   theme?: OnboardingTheme;
+  showPaywall?: boolean;
+  paywallComponent?: React.ReactNode;
 }
 
 export interface OnboardingSlideProps {


### PR DESCRIPTION
## Summary
- Add paywall display option after onboarding completion
- Only shows paywall when `showPaywall=true` AND `paywallComponent` is provided
- Paywall component receives `onComplete` callback to close the flow
- Maintains existing behavior when paywall is disabled

## Changes
- Added `showPaywall` and `paywallComponent` props to `OnboardingFlowProps` and `OnboardingModalProps`
- Updated `OnboardingFlow.tsx` to handle paywall display logic after last slide
- Modified `OnboardingModal.tsx` to render paywall component in full screen when conditions are met
- Added proper state management for paywall display

## Usage
```tsx
<OnboardingFlow
  slides={slides}
  visible={visible}
  onComplete={() => console.log('Onboarding completed')}
  showPaywall={true}
  paywallComponent={<MyPaywallComponent />}
/>
```

The paywall component will receive an `onComplete` prop that should be called when the user is done with the paywall.

🤖 Generated with [Claude Code](https://claude.ai/code)