### PR TITLE
feat: add borderRadius customization for media elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ const App = () => {
         source: require('./assets/features.png'),
         width: 300,
         height: 200,
+        borderRadius: 20,
       },
       title: 'Powerful Features',
       description: 'Everything you need in one place',
@@ -192,6 +193,9 @@ interface OnboardingSlideData {
     autoPlay?: boolean; // For videos (default: true)
     loop?: boolean; // For videos (default: true)  
     muted?: boolean; // For videos (default: true)
+    width?: number; // Custom width in pixels
+    height?: number; // Custom height in pixels
+    borderRadius?: number; // Custom border radius in pixels
   };
   title: string;
   description: string;
@@ -210,6 +214,7 @@ interface OnboardingSlideData {
 | `muted` | `boolean` | `true` | Start videos muted |
 | `width` | `number` | `screenWidth * 0.6` | Custom width in pixels (default: 60% of screen width) |
 | `height` | `number` | `screenWidth * 0.6` | Custom height in pixels (default: 60% of screen width) |
+| `borderRadius` | `number` | `12` (videos), `undefined` (images) | Border radius in pixels |
 
 ### Theme Colors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-onboarding-flow",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-onboarding-flow",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.2.1",

--- a/src/components/OnboardingSlide.tsx
+++ b/src/components/OnboardingSlide.tsx
@@ -60,15 +60,24 @@ const OnboardingSlide: React.FC<OnboardingSlideProps> = ({ slide, isActive, them
         height: mediaData.height || width * 0.6,
         opacity: mediaOpacity,
         transform: [{ scale: mediaScale }],
+        borderRadius: mediaData.borderRadius,
+        overflow: 'hidden',
       },
     ];
 
     if (mediaData.type === 'video') {
+      const videoStyle = [
+        styles.video,
+        {
+          borderRadius: mediaData.borderRadius || 12,
+        },
+      ];
+
       return (
         <Animated.View style={mediaStyle}>
           <Video
             source={mediaData.source}
-            style={styles.video}
+            style={videoStyle}
             resizeMode={ResizeMode.CONTAIN}
             shouldPlay={isActive && (mediaData.autoPlay !== false)}
             isLooping={mediaData.loop !== false}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface OnboardingSlideData {
     muted?: boolean; // For videos (default: true)
     width?: number; // Custom width in pixels
     height?: number; // Custom height in pixels
+    borderRadius?: number; // Custom border radius in pixels
   };
   title: string;
   description: string;


### PR DESCRIPTION
## Summary

This PR adds support for customizing the border radius of video and image elements in onboarding slides. Users can now specify a `borderRadius` property in the media object to control the rounded corners of their media content.

## Changes Made

- Added `borderRadius` optional property to the media interface in `types.ts`
- Updated `OnboardingSlide.tsx` to apply borderRadius styling to both video and image elements
- Set sensible defaults: 12px border radius for videos, undefined (no border radius) for images
- Added comprehensive documentation to `README.md` with examples and property descriptions
- Ensured proper overflow handling to maintain clean rounded corners

## Testing

- TypeScript build passes successfully
- Feature allows fine-grained control over media element styling
- Maintains backward compatibility - existing implementations continue to work unchanged
- Default behavior provides good UX out of the box

## Example Usage

```javascript
{
  media: {
    type: 'image',
    source: require('./assets/features.png'),
    width: 300,
    height: 200,
    borderRadius: 20, // Custom border radius
  },
  title: 'Powerful Features',
  description: 'Everything you need in one place',
}
```

## Breaking Changes

None - this is a backward-compatible enhancement.

🤖 Generated with [Claude Code](https://claude.ai/code)