### PR TITLE
fix: use dynamic require for expo-av to bypass Metro static resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-onboarding-flow",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-onboarding-flow",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onboarding-flow",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Beautiful, customizable onboarding flows for React Native with smooth animations",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/components/OnboardingSlide.tsx
+++ b/src/components/OnboardingSlide.tsx
@@ -15,7 +15,8 @@ let _ResizeMode: any;
 function getExpoAV() {
   if (!_Video) {
     try {
-      const av = require('expo-av');
+      const expoAv = ['expo', 'av'].join('-');
+      const av = require(expoAv);
       _Video = av.Video;
       _ResizeMode = av.ResizeMode;
     } catch (e) {


### PR DESCRIPTION
## Summary
- Replaces `require('expo-av')` with `require(['expo', 'av'].join('-'))` so Metro bundler can't statically resolve the module at bundle time
- Keeps the try-catch for a clear runtime error if someone uses a video slide without expo-av installed
- Supersedes #15 — try-catch alone wasn't sufficient since Metro extracts string literals before code execution
- Bumps version to v1.5.2

## Test plan
- [x] All 10 tests pass
- [x] Build succeeds
- [ ] Verify in a consuming app without expo-av that image-only onboarding bundles and runs
- [ ] Verify in a consuming app with expo-av that video slides still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)